### PR TITLE
Require doctrine/orm:~2.3 and Nette ~2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 	"license": "MIT",
 	"require": {
 		"php": ">=5.3.2",
-		"nette/nette": ">=2.0,<=2.1",
-		"doctrine/orm": ">=2.3,<=2.4"
+		"nette/nette": "~2.0",
+		"doctrine/orm": "~2.3"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
This should allow to install doctrine 2.4.1 and Nette 2.1-dev (if required)
